### PR TITLE
Make sure the StopIteration exception is not caught by the main function

### DIFF
--- a/AIPSnapshotCleaner.py
+++ b/AIPSnapshotCleaner.py
@@ -488,7 +488,7 @@ def drop_snapshots():
         try:
             adg_db = next(item for item in apps if item["name"] == app_name)['adgDatabase']
         except StopIteration:
-            continue
+            pass
 
         # Get the connection profile name from the connection_profiles list, using the
         # mngt schema name.
@@ -497,7 +497,7 @@ def drop_snapshots():
         try:
             profile_name = next(item for item in connection_profiles if item["schema"] == mngt_name)['name']
         except StopIteration:
-            continue
+            pass
 
         if (prev_app_name == ''):
             prev_app_name = app_name

--- a/AIPSnapshotCleaner.py
+++ b/AIPSnapshotCleaner.py
@@ -3,15 +3,15 @@ Name: AIPSnapshotCleaner.py
 
 Author: Guru Pai
 
-Date: Thu 05/24/2019 
+Date: Thu 05/24/2019
 
 # TODO
 This python script inserts two background facts into AAD.
-1. 
-2. 
+1.
+2.
 
 Arguments:
-1. 
+1.
 
 NOTE:
 By design, this script populates the background fact for a single app.
@@ -183,7 +183,7 @@ def get_snapshots(s_href):
                 data = response.json()
 
             for item in data:
-                # We just need that latest snapshot id, as that is the only thing snapshot 
+                # We just need that latest snapshot id, as that is the only thing snapshot
                 # that needs to be updated. The REST call returns that as the first entry.
 
                 snapshot = {}
@@ -211,7 +211,7 @@ def mark_snapshots_for_deletion():
     """
     This function marks snapshots that are to be deleted. It does NOT DELETE them.
 
-    Snapshots which need to be deleted are marked for deletion by setting the delete_flag 
+    Snapshots which need to be deleted are marked for deletion by setting the delete_flag
     to True, in the snapshot_info list.
 
     Logic:
@@ -219,7 +219,7 @@ def mark_snapshots_for_deletion():
     2. Check which year it belongs to. The script only considers the current year, previous year
        and other years.
     3. Loop thru each snapshot in snapshot_info:
-    4.    For each snapshot for an app, based on the retention criteria for the current, previous and other years, 
+    4.    For each snapshot for an app, based on the retention criteria for the current, previous and other years,
           call the appropriate funtion to determine if the snapshot is the latest or if there are later snapshots.
     5.    If a newer snapshot exists, mark the current snapshot for deletion UNLESS it meets the 'keep_latest_n_snapshots'
           criteria.
@@ -253,7 +253,7 @@ def mark_snapshots_for_deletion():
 
         # Retain the latest N snapshots, as specified in the YAML file.
         #
-        # NOTE: The REST call always returns snapshots in a descending order. 
+        # NOTE: The REST call always returns snapshots in a descending order.
         #       Leveraging this feature to avoid additional processing.
 
         snapshot_counter += 1
@@ -268,7 +268,7 @@ def mark_snapshots_for_deletion():
             pass
 
         if (snapshot_counter <= latest_snapshots_to_keep):
-            # Keeping the latest set of N snapshots for the app. 
+            # Keeping the latest set of N snapshots for the app.
             logger.info('Application:%s|Snapshot:%s| Snapshot will not be deleted as %d latest snapshots are to be kept. Skipping.' % (app_name, snap_dttm, latest_snapshots_to_keep))
             continue
 
@@ -303,8 +303,8 @@ def mark_snapshots_for_deletion():
             elif (other_years_policy == 'Y'):
                 ret_policy = 'Yearly'
         else:
-            # TODO: 
-            # ERROR: Unhandled. 
+            # TODO:
+            # ERROR: Unhandled.
             pass
 
         # Mark snapshots for deletion, based on the retention policy.
@@ -347,7 +347,7 @@ def mark_snapshots_for_deletion():
 def is_snapshot_latest_monthly(application_name, snapshot_datetime):
     is_latest = True # Default to True.
 
-    # For the given app, need to iterate over the snapshots for the current month 
+    # For the given app, need to iterate over the snapshots for the current month
     # and year and determine if the snapshot is the latest for the month.
 
     snapshot_year = int(snapshot_datetime.strftime('%Y'))
@@ -377,7 +377,7 @@ def is_snapshot_latest_quarterly(application_name, snapshot_datetime):
     is_latest = False
     num_snapshots_in_qtr = 0
 
-    # For the given app, need to iterate over the snapshots for the current month 
+    # For the given app, need to iterate over the snapshots for the current month
     # and year and determine if the snapshot is the latest for the month.
 
     snapshot_year = int(snapshot_datetime.strftime('%Y'))
@@ -414,7 +414,7 @@ def is_snapshot_latest_yearly(application_name, snapshot_datetime):
     is_latest = False
     num_snapshots_in_year = 0
 
-    # For the given app, need to iterate over the snapshots for the current month 
+    # For the given app, need to iterate over the snapshots for the current month
     # and year and determine if the snapshot is the latest for the month.
 
     snapshot_year = int(snapshot_datetime.strftime('%Y'))
@@ -451,7 +451,7 @@ def preserve_baseline_snapshots():
     min_snap_dttm = ''
     temp_app_name = ''
 
-    # For the given app, need to iterate over the snapshots for the current month 
+    # For the given app, need to iterate over the snapshots for the current month
     # and year and determine if the snapshot is the latest for the month.
 
     for i, elem in enumerate(snapshot_info):
@@ -460,7 +460,7 @@ def preserve_baseline_snapshots():
 
         app_dict = [x['snap_dttm'] for x in snapshot_info if x['app_name'] == app_name]
         #print(app_dict)
-        
+
         min_snap_dttm = min(app_dict)
         #print('min_snap_dttm:%s' % min_snap_dttm)
 
@@ -474,7 +474,7 @@ def preserve_baseline_snapshots():
 
 def drop_snapshots():
     # NOTE:
-    # Snapshots will NOT BE DELETED unless the argument 'drop-snapshots' is 
+    # Snapshots will NOT BE DELETED unless the argument 'drop-snapshots' is
     # passed in. Otherwise, the program only displays the list of snapshots
     # that have been marked for deletion but no snapshots will be deleted.
     prev_app_name = ''
@@ -484,12 +484,20 @@ def drop_snapshots():
     for snapshot in snapshot_info:
         # Get the central schema name from the apps list, by searching the app name.
         app_name = snapshot['app_name']
-        adg_db = next(item for item in apps if item["name"] == app_name)['adgDatabase']
+        # as per https://help.semmle.com/wiki/display/PYTHON/Unguarded+next+in+generator
+        try:
+            adg_db = next(item for item in apps if item["name"] == app_name)['adgDatabase']
+        except StopIteration:
+            continue
 
-        # Get the connection profile name from the connection_profiles list, using the 
+        # Get the connection profile name from the connection_profiles list, using the
         # mngt schema name.
         mngt_name = adg_db.replace('_central', '_mngt')
-        profile_name = next(item for item in connection_profiles if item["schema"] == mngt_name)['name']
+        # as per https://help.semmle.com/wiki/display/PYTHON/Unguarded+next+in+generator
+        try:
+            profile_name = next(item for item in connection_profiles if item["schema"] == mngt_name)['name']
+        except StopIteration:
+            continue
 
         if (prev_app_name == ''):
             prev_app_name = app_name


### PR DESCRIPTION
When the **next()** generator gets exhausted it will raise a **StopIteration** exception which gets caught in the **main()** function and makes the script terminate **prematurely**.

Why is this an issue? The **StopIteration** exception should not terminate the main script as this doesn't mean the list of items over which we iterate is empty.

What part of script is affected:
```
def main():
    global base_url, domain, username, password, CAST_HOME
    try:
        # Read the YAML file to get the config settings.
        read_yaml()
        ...
       # Delete snapshots that are marked for deletion.
        drop_snapshots()  # -----------> here the StopIteration exception is raised by the next() generator
    except:
        logger.error('Aborting due to a prior exception. See the log file for complete details.')
        sys.exit(6)
    else:
        pass