### PR TITLE
Provide project requirements.txt to keep track of dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,15 @@
 # AIP Snapshot Cleaner
 
-This script can be used to cleanup older snapshots in CAST AIP. Snapshots are cleaned up based on  the retention criteria specified in 
+This script can be used to cleanup older snapshots in CAST AIP. Snapshots are cleaned up based on  the retention criteria specified in
 the resources/AIPCleaner.yaml file.
 
 ## Prerequisites
-The script is written in Python. Ensure that you have Python __3.6__ or above installed. 
+The script is written in Python. Ensure that you have Python __3.6__ or above installed.
 It uses the following Python packages. Ensure these are installed using the Python __PIP__ command. PIP installs dependent packages, where needed.
 
-- requests
-- PyYAML
+From this project root directory:
+
+`pip install -r requirements.txt`
 
 Refer to [Installing Python Modules](https://docs.python.org/3.6/installing/) webpage for more information on how to install Python modules.
 
@@ -33,19 +34,19 @@ retention_policy:
 
 Use the following option to ensure that the latest N number of snapshots are always kept:
   keep_latest_n_snapshots: 5
-  
+
 Additionally, use the following option to retain baseline snapshots:
   keep_baseline: true
 ```
 
 ## Other settings
-Update the AAD URL, credentials, name and location of the CAST-MS PMX file, log folder location and CAST installation folder location. 
+Update the AAD URL, credentials, name and location of the CAST-MS PMX file, log folder location and CAST installation folder location.
 
 ## Before running cleanup
-The script deletes the snapshots that match the criteria specified, using the __CAST-MS CLI__ command. This causes snapshots to be dropped from the dashboard service schema for each of the apps. So before running cleanup each time, ensure that the dashboard service schema is backed up. 
+The script deletes the snapshots that match the criteria specified, using the __CAST-MS CLI__ command. This causes snapshots to be dropped from the dashboard service schema for each of the apps. So before running cleanup each time, ensure that the dashboard service schema is backed up.
 
 ## How to run the cleanup script
-The script can by running by invoking python and passing in the name of the script as an argument. Before starting, change directoy to move to the script folder. 
+The script can by running by invoking python and passing in the name of the script as an argument. Before starting, change directoy to move to the script folder.
 
 ``python AIPSnapshotCleaner.py`` - This will invoke the script in a display only mode, where it does not delete snapshots, but will display which snapshots will be dropped. To drop outdated snapshots, invoke the script with a __-drop__ argument as in: ``python AIPSnapshotCleaner.py -drop``
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+requests==2.22.0
+PyYAML==5.1.2


### PR DESCRIPTION
In order to keep track of a python project dependencies and their required version a special file called `requirements.txt` can be used.

Then it's just a matter of: `pip install -r requirements.txt`.